### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/exportHTML.js
+++ b/exportHTML.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 
 // Add non-used props to be supported in export
 exports.exportHtmlAdditionalTagsWithData = async (hookName, pad) => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
 // Tries to include content that never existed...

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
   },
-  "version": "0.0.25"
+  "version": "0.0.26"
 }


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.